### PR TITLE
Removing package() call for L5 support.

### DIFF
--- a/src/HieuLe/Active/ActiveServiceProvider.php
+++ b/src/HieuLe/Active/ActiveServiceProvider.php
@@ -21,7 +21,7 @@ class ActiveServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-	$this->package('hieu-le/active');
+        //$this->package('hieu-le/active');
     }
 
     /**


### PR DESCRIPTION
Laravel 5 removed the `package()` function from Service Providers. Removing it seems to get this package back to full L5 support :-)