### PR TITLE
Update Active.php to match behavior of documentation

### DIFF
--- a/src/Active.php
+++ b/src/Active.php
@@ -169,7 +169,8 @@ class Active
      */
     public function action($actions, $class = 'active')
     {
-        $routeAction = $this->_router->currentRouteAction();
+        $routeExploded = explode('\\',$this->_router->currentRouteAction());
+        $routeAction = end($routeExploded );
 
         if (!is_array($actions))
         {


### PR DESCRIPTION
Specifically these lines

> Return string 'active' if current route lead to the method 'getFoo' of the class 'FooController'
Active::action('FooController@getFoo');
 
> Return string 'selected' if current route lead to the method 'getFoo' of the class 'FooController' or the method 'postBar' of the class 'BarController'
Active::action(array('FooController@getFoo', 'BarController@postBar'), 'selected');

It appears in laravel 5 $this->_router->currentRouteAction(); returns the full path to the controller so this function was not behaving correctly.