### PR TITLE
Update ActiveServiceProvider.php to work with Laravel 5.2

### DIFF
--- a/src/ActiveServiceProvider.php
+++ b/src/ActiveServiceProvider.php
@@ -18,8 +18,8 @@ class ActiveServiceProvider extends ServiceProvider
     {
         // Update the instances each time a request is resolved and a route is matched
         $instance = app('active');
-        app('router')->matched(function ($route, $request) use ($instance) {
-            $instance->updateInstances($route, $request);
+        app('router')->matched(function ($routeMatched) use ($instance) {
+            $instance->updateInstances($routeMatched->route, $routeMatched->request);
         });
     }
 


### PR DESCRIPTION
The Router::matched injects RouteMatch object in Laravel 5.2.
I made some adjustments to work with this.