### PR TITLE
Updated for Laravel 5.2

### DIFF
--- a/src/ActiveServiceProvider.php
+++ b/src/ActiveServiceProvider.php
@@ -18,8 +18,8 @@ class ActiveServiceProvider extends ServiceProvider
     {
         // Update the instances each time a request is resolved and a route is matched
         $instance = app('active');
-        app('router')->matched(function ($route, $request) use ($instance) {
-            $instance->updateInstances($route, $request);
+        app('router')->matched(function ($routeMatched) use ($instance) {
+            $instance->updateInstances($routeMatched->route, $routeMatched->request);
         });
     }
 


### PR DESCRIPTION
[Laravel 5.2 changed](https://laravel.com/docs/5.2/upgrade#upgrade-5.2.0) events from strings to objects, so the `ActiveServiceProvider` had to be updated accordingly.

The `route.matched` event is now a `Illuminate\Routing\Events\RouteMatched` object.