### PR TITLE
fix empty route matching single pattern

### DIFF
--- a/src/Active.php
+++ b/src/Active.php
@@ -218,7 +218,7 @@ class Active
      *
      * @return bool
      */
-    public function checkRoutePattern($patterns)
+    public function checkRoutePattern($patterns): bool
     {
         if (!$this->route) {
             return false;
@@ -227,7 +227,7 @@ class Active
         $routeName = $this->route->getName();
 
         if ($routeName == null) {
-            return in_array(null, $patterns);
+            return in_array(null, (array) $patterns);
         }
 
         foreach ((array)$patterns as $p) {

--- a/tests/ActiveTest.php
+++ b/tests/ActiveTest.php
@@ -154,13 +154,13 @@ class ActiveTest extends TestCase
     }
 
     /**
-     * @param Request $request
-     * @param         $routes
-     * @param         $result
+     * @param ?Request $request
+     * @param          $routes
+     * @param          $result
      *
      * @dataProvider provideCheckRoutePatternTestData
      */
-    public function testCheckCurrentRoutePattern(Request $request, $routes, $result)
+    public function testCheckCurrentRoutePattern(?Request $request, $routes, $result)
     {
         app(HttpKernelContract::class)->handle($request);
 
@@ -420,6 +420,11 @@ class ActiveTest extends TestCase
                 Request::create('/'),
                 ['foo.*', null],
                 true,
+            ],
+            'route with no name and single pattern'    => [
+                Request::create('/'),
+                'foo.*',
+                false,
             ],
         ];
     }


### PR DESCRIPTION
Hi,

This will fix the issue below

```php
TypeError: in_array(): Argument #2 ($haystack) must be of type array, string given

src\Active.php:230
vendor\laravel\framework\src\Illuminate\Support\Facades\Facade.php:261
```